### PR TITLE
Add Markov Chains With Back-off

### DIFF
--- a/Markov.Tests/ChainStateTests.cs
+++ b/Markov.Tests/ChainStateTests.cs
@@ -1,4 +1,4 @@
-// Copyright © John Gietzen. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
+// Copyright © John Gietzen and Contributors. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
 
 namespace Markov.Tests
 {

--- a/Markov.Tests/Markov.Tests.csproj
+++ b/Markov.Tests/Markov.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FixMe" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="All" />
+    <PackageReference Include="GitVersionTask" Version="5.0.0-beta3-4" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/Markov.Tests/MarkovChainTests.cs
+++ b/Markov.Tests/MarkovChainTests.cs
@@ -1,4 +1,4 @@
-// Copyright © John Gietzen. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
+// Copyright © John Gietzen and Contributors. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
 
 namespace Markov.Tests
 {

--- a/Markov.Tests/MarkovChainWithBackoffTests.cs
+++ b/Markov.Tests/MarkovChainWithBackoffTests.cs
@@ -1,4 +1,4 @@
-// Copyright © John Gietzen. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
+// Copyright © John Gietzen and Contributors. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
 
 namespace Markov.Tests
 {

--- a/Markov.Tests/MarkovChainWithBackoffTests.cs
+++ b/Markov.Tests/MarkovChainWithBackoffTests.cs
@@ -4,10 +4,38 @@ namespace Markov.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using Newtonsoft.Json;
     using Xunit;
 
     public class MarkovChainWithBackoffTests
     {
+        public static readonly string EmptySample = @"{}";
+
+        public static object[][] GetSerializationSamples()
+        {
+            return new[]
+          {
+            new object[] { "fool", 1, @"{'':{'f':1},'f':{'o':1},'o':{'o':1,'l':1},'l':{'':1}}" },
+            new object[] { "fool", 2, @"{'fo':{'o':1,'l':1},'oo':{'o':1,'l':1},'ol':{'':1},'':{'f':1},'f':{'o':1},'o':{'o':1,'l':1},'l':{'':1}}" },
+            new object[] { "food", 1, @"{'':{'f':1},'f':{'o':1},'o':{'o':1,'d':1},'d':{'':1}}" },
+            new object[] { "food", 2, @"{'fo':{'o':1,'d':1},'oo':{'o':1,'d':1},'od':{'':1},'':{'f':1},'f':{'o':1},'o':{'o':1,'d':1},'d':{'':1}}" },
+            new object[] { "loose", 1, @"{'':{'l':1},'l':{'o':1},'o':{'o':1,'s':1},'s':{'e':1},'e':{'':1}}" },
+            new object[] { "loose", 2, @"{'lo':{'o':1,'s':1},'oo':{'o':1,'s':1},'os':{'e':1},'se':{'':1},'':{'l':1},'l':{'o':1},'o':{'o':1,'s':1},'s':{'e':1},'e':{'':1}}" },
+        };
+        }
+
+        public static IEnumerable<object[]> GetSampleDataForOppositeWeights()
+        {
+            foreach (var word in new string[] { "fool", "food", "loose" })
+            {
+                foreach (var maximumOrder in new int[] { 1, 2, 3, 10 })
+                {
+                    yield return new object[] { word, maximumOrder };
+                }
+            }
+        }
+
         [Fact]
         public void Chain_WithRestrictiveMaximumOrder_DoesntAlwaysQuoteCorpus()
         {
@@ -36,6 +64,85 @@ namespace Markov.Tests
         {
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 new MarkovChainWithBackoff<char>(maximumOrder, 10));
+        }
+
+        [Fact]
+        public void GetNextStates_WithoutRestrictiveDesiredNextStatesValue_DoesntBackOff()
+        {
+            var chainWithBackoff = new MarkovChainWithBackoff<char>(5, 1);
+            chainWithBackoff.Add("fool");
+
+            var nextStates = chainWithBackoff.GetNextStates("foo");
+
+            Assert.Equal(nextStates, new Dictionary<char, int> { { 'l', 1 } });
+        }
+
+        [Fact]
+        public void GetNextStates_WithRestrictiveDesiredNextStatesValue_DoesBackOff()
+        {
+            var chainWithBackoff = new MarkovChainWithBackoff<char>(5, 2);
+            chainWithBackoff.Add("fool");
+
+            var nextStates = chainWithBackoff.GetNextStates("foo");
+
+            Assert.Equal(nextStates, new Dictionary<char, int> { { 'o', 1 }, { 'l', 1 } });
+        }
+
+        [Fact]
+        public void GetNextStates_WithOverRestrictiveDesiredNextStatesValue_PicksBestPossibleOrder()
+        {
+            var chainWithBackoff = new MarkovChainWithBackoff<char>(5, 3);
+            chainWithBackoff.Add("fool");
+
+            var nextStates = chainWithBackoff.GetNextStates("foo");
+
+            Assert.Equal(nextStates, new Dictionary<char, int> { { 'o', 1 }, { 'l', 1 } });
+        }
+
+        [Theory]
+        [MemberData(nameof(GetSerializationSamples))]
+        public void Add_WhenEmpty_AddsTheValuesToTheState(string sample, int maximumOrder, string serialized)
+        {
+            var chain = new MarkovChainWithBackoff<char>(maximumOrder, 2);
+
+            chain.Add(sample);
+
+            var result = Serialize(chain);
+            Assert.Equal(serialized, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetSampleDataForOppositeWeights))]
+        public void Add_WithOppositeWeight_ResetsInternalsToInitialState(string word, int maximumOrder)
+        {
+            var chain = new MarkovChainWithBackoff<char>(maximumOrder, 2);
+            chain.Add(word, 1);
+
+            chain.Add(word, -1);
+
+            var result = Serialize(chain);
+            Assert.Equal(EmptySample, result);
+        }
+
+        private static string Serialize(MarkovChain<char> chain)
+        {
+            var states = chain.GetStates().ToDictionary(
+                s => string.Concat(s),
+                s =>
+                {
+                    var next = chain.GetNextStates(s) ?? Enumerable.Empty<KeyValuePair<char, int>>();
+                    var result = next.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value);
+
+                    var terminal = chain.GetTerminalWeight(s);
+                    if (terminal > 0)
+                    {
+                        result[string.Empty] = terminal;
+                    }
+
+                    return result;
+                });
+
+            return JsonConvert.SerializeObject(states).Replace('\"', '\'');
         }
     }
 }

--- a/Markov.Tests/MarkovChainWithBackoffTests.cs
+++ b/Markov.Tests/MarkovChainWithBackoffTests.cs
@@ -1,0 +1,41 @@
+// Copyright © John Gietzen. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
+
+namespace Markov.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using Xunit;
+
+    public class MarkovChainWithBackoffTests
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-100)]
+        [InlineData(int.MinValue)]
+        public void Ctor_WithMaximumOrderLessThanOne_ThrowsArgumentOutOfRangeException(int maximumOrder)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new MarkovChainWithBackoff<char>(maximumOrder, 10));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(-100)]
+        [InlineData(int.MinValue)]
+        public void Ctor_WithDesiredNumNextStatesLessThanZero_ThrowsArgumentOutOfRangeException(int desiredNumNextStates)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new MarkovChainWithBackoff<char>(10, desiredNumNextStates));
+        }
+
+        [Fact]
+        public void Chain_WithRestrictiveMaximumOrder_DoesntAlwaysQuoteCorpus()
+        {
+            MarkovChainWithBackoff<char> chainWithBackoff = new MarkovChainWithBackoff<char>(5, 2);
+            chainWithBackoff.Add("fool");
+            Random deterministicRand = new Random(0);
+            string resultWithBackoff = string.Join("", chainWithBackoff.Chain(deterministicRand));
+            Assert.Equal("fol", resultWithBackoff);
+        }
+    }
+}

--- a/Markov.Tests/MarkovChainWithBackoffTests.cs
+++ b/Markov.Tests/MarkovChainWithBackoffTests.cs
@@ -8,14 +8,14 @@ namespace Markov.Tests
 
     public class MarkovChainWithBackoffTests
     {
-        [Theory]
-        [InlineData(0)]
-        [InlineData(-100)]
-        [InlineData(int.MinValue)]
-        public void Ctor_WithMaximumOrderLessThanOne_ThrowsArgumentOutOfRangeException(int maximumOrder)
+        [Fact]
+        public void Chain_WithRestrictiveMaximumOrder_DoesntAlwaysQuoteCorpus()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-                new MarkovChainWithBackoff<char>(maximumOrder, 10));
+            var chainWithBackoff = new MarkovChainWithBackoff<char>(5, 2);
+            chainWithBackoff.Add("fool");
+            var deterministicRand = new Random(0);
+            var resultWithBackoff = string.Join("", chainWithBackoff.Chain(deterministicRand));
+            Assert.Equal("fol", resultWithBackoff);
         }
 
         [Theory]
@@ -28,14 +28,14 @@ namespace Markov.Tests
                 new MarkovChainWithBackoff<char>(10, desiredNumNextStates));
         }
 
-        [Fact]
-        public void Chain_WithRestrictiveMaximumOrder_DoesntAlwaysQuoteCorpus()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-100)]
+        [InlineData(int.MinValue)]
+        public void Ctor_WithMaximumOrderLessThanOne_ThrowsArgumentOutOfRangeException(int maximumOrder)
         {
-            MarkovChainWithBackoff<char> chainWithBackoff = new MarkovChainWithBackoff<char>(5, 2);
-            chainWithBackoff.Add("fool");
-            Random deterministicRand = new Random(0);
-            string resultWithBackoff = string.Join("", chainWithBackoff.Chain(deterministicRand));
-            Assert.Equal("fol", resultWithBackoff);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new MarkovChainWithBackoff<char>(maximumOrder, 10));
         }
     }
 }

--- a/Markov/ChainState.cs
+++ b/Markov/ChainState.cs
@@ -1,4 +1,4 @@
-// Copyright © John Gietzen. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
+// Copyright © John Gietzen and Contributors. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
 
 namespace Markov
 {

--- a/Markov/Markov.csproj
+++ b/Markov/Markov.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FixMe" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="All" />
+    <PackageReference Include="GitVersionTask" Version="5.0.0-beta3-4" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" PrivateAssets="All" />
   </ItemGroup>

--- a/Markov/MarkovChain.cs
+++ b/Markov/MarkovChain.cs
@@ -1,4 +1,4 @@
-// Copyright © John Gietzen. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
+// Copyright © John Gietzen and Contributors. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
 
 namespace Markov
 {

--- a/Markov/MarkovChain.cs
+++ b/Markov/MarkovChain.cs
@@ -79,18 +79,7 @@ namespace Markov
                 }
             }
 
-            var terminalKey = new ChainState<T>(previous);
-            var newWeight = Math.Max(0, this.terminals.ContainsKey(terminalKey)
-                ? weight + this.terminals[terminalKey]
-                : weight);
-            if (newWeight == 0)
-            {
-                this.terminals.Remove(terminalKey);
-            }
-            else
-            {
-                this.terminals[terminalKey] = newWeight;
-            }
+            this.AddTerminalInternal(new ChainState<T>(previous), weight);
         }
 
         /// <summary>
@@ -168,7 +157,7 @@ namespace Markov
         /// of the specified state transition.  This can therefore be used to remove items from
         /// the generator. The resulting weight will never be allowed below zero.
         /// </remarks>
-        public void Add(ChainState<T> state, T next, int weight)
+        public virtual void Add(ChainState<T> state, T next, int weight)
         {
             if (state == null)
             {
@@ -263,12 +252,13 @@ namespace Markov
 
                 var key = new ChainState<T>(state);
 
-                if (!this.items.TryGetValue(key, out var weights))
+                var weights = this.GetNextStatesInternal(key);
+                if (weights == null)
                 {
                     yield break;
                 }
 
-                this.terminals.TryGetValue(key, out var terminalWeight);
+                var terminalWeight = this.GetTerminalWeight(key);
 
                 var total = weights.Sum(w => w.Value);
                 var value = rand.Next(total + terminalWeight) + 1;
@@ -321,19 +311,15 @@ namespace Markov
         /// <returns>A dictionary of the items and their weight.</returns>
         public Dictionary<T, int> GetNextStates(ChainState<T> state)
         {
-            if (this.items.TryGetValue(state, out var weights))
-            {
-                return new Dictionary<T, int>(weights);
-            }
-
-            return null;
+            var weights = this.GetNextStatesInternal(state);
+            return weights != null ? new Dictionary<T, int>(weights) : null;
         }
 
         /// <summary>
         /// Gets all of the states that exist in the generator.
         /// </summary>
         /// <returns>An enumerable collection of <see cref="ChainState{T}"/> containing all of the states in the generator.</returns>
-        public IEnumerable<ChainState<T>> GetStates()
+        public virtual IEnumerable<ChainState<T>> GetStates()
         {
             foreach (var state in this.items.Keys)
             {
@@ -370,10 +356,40 @@ namespace Markov
         /// </summary>
         /// <param name="state">The state preceding the items of interest.</param>
         /// <returns>A dictionary of the items and their weight.</returns>
-        public int GetTerminalWeight(ChainState<T> state)
+        public virtual int GetTerminalWeight(ChainState<T> state)
         {
             this.terminals.TryGetValue(state, out var weight);
             return weight;
         }
+
+        /// <summary>
+        /// Add a terminal with the given weight. Can be overridden by inheriting classes.
+        /// </summary>
+        /// <param name="state">The state preceding the items of interest.</param>
+        /// <param name="weight">The weight of the terminal to add.</param>
+        protected internal virtual void AddTerminalInternal(ChainState<T> state, int weight)
+        {
+            var newWeight = Math.Max(0, this.terminals.ContainsKey(state)
+                ? weight + this.terminals[state]
+                : weight);
+            if (newWeight == 0)
+            {
+                this.terminals.Remove(state);
+            }
+            else
+            {
+                this.terminals[state] = newWeight;
+            }
+        }
+
+        /// <summary>
+        /// Gets the items from the generator that follow from the specified state preceding it without copying the values.
+        /// </summary>
+        /// <param name="state">The state preceding the items of interest.</param>
+        /// <returns>The raw dictionary of the items and their weight.</returns>
+        protected internal virtual Dictionary<T, int> GetNextStatesInternal(ChainState<T> state) =>
+            this.items.TryGetValue(state, out var weights)
+                ? weights
+                : null;
     }
 }

--- a/Markov/MarkovChain.cs
+++ b/Markov/MarkovChain.cs
@@ -40,6 +40,14 @@ namespace Markov
         }
 
         /// <summary>
+        /// Gets the order of the chain.
+        /// </summary>
+        public int Order
+        {
+            get => this.order;
+        }
+
+        /// <summary>
         /// Adds the items to the generator with a weight of one.
         /// </summary>
         /// <param name="items">The items to add to the generator.</param>

--- a/Markov/MarkovChainWithBackoff.cs
+++ b/Markov/MarkovChainWithBackoff.cs
@@ -1,0 +1,56 @@
+// Copyright © John Gietzen. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
+
+namespace Markov
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Builds and walks interconnected states based on probabilities probed at different depths.
+    /// </summary>
+    /// <typeparam name="T">The type of the constituent parts of each state in the Markov chain.</typeparam>
+    public class MarkovChainWithBackoff<T>
+        where T : IEquatable<T>
+    {
+        private readonly int maximumOrder;
+        private readonly int desiredNumNextStates;
+        private readonly List<MarkovChain<T>> chains = new List<MarkovChain<T>>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MarkovChainWithBackoff{T}"/> class.
+        /// </summary>
+        /// <param name="maximumOrder">Indicates the maximum/starting order of the <see cref="MarkovChainWithBackoff{T}"/>.</param>
+        /// <param name="desiredNumNextStates">Indicates the desired number of next states of the <see cref="MarkovChainWithBackoff{T}"/>.</param>
+        /// <remarks>
+        /// <para>The order of a traditional markov generator indicates the depth of its internal state. A generator
+        /// with an order of 1 will choose items based on the previous item, a generator with an order of 2
+        /// will choose items based on the previous 2 items, and so on.</para>
+        /// <para>In a <see cref="MarkovChainWithBackoff{T}"/> we start with an order of <paramref name="maximumOrder"/>.
+        /// We peak at the next possible and if we have more than <paramref name="desiredNumNextStates"/> we generate
+        /// at that order. If we don't have enough next possible states we lower the order by 1 and repeat. If we reach
+        /// an order of one we generate regardless of the number of possible states.</para>
+        /// <para>One is the lowest valid <paramref name="maximumOrder"/> and zero is the lowest valid<paramref name="desiredNumNextStates"/>.</para>
+        /// </remarks>
+        public MarkovChainWithBackoff(int maximumOrder, int desiredNumNextStates)
+        {
+            if (maximumOrder < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximumOrder));
+            }
+
+            if (desiredNumNextStates < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(desiredNumNextStates));
+            }
+
+            this.maximumOrder = maximumOrder;
+            this.desiredNumNextStates = desiredNumNextStates;
+
+            for (int order = maximumOrder; order > 0; order--)
+            {
+                this.chains.Add(new MarkovChain<T>(order));
+            }
+        }
+    }
+}

--- a/Markov/MarkovChainWithBackoff.cs
+++ b/Markov/MarkovChainWithBackoff.cs
@@ -1,4 +1,4 @@
-// Copyright © John Gietzen. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
+// Copyright © John Gietzen and Contributors. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.
 
 namespace Markov
 {

--- a/Markov/MarkovChainWithBackoff.cs
+++ b/Markov/MarkovChainWithBackoff.cs
@@ -14,8 +14,8 @@ namespace Markov
         where T : IEquatable<T>
     {
         private readonly int maximumOrder;
-        private readonly int desiredNumNextStates;
         private readonly List<MarkovChain<T>> chains = new List<MarkovChain<T>>();
+        private readonly int desiredNumNextStates;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MarkovChainWithBackoff{T}"/> class.
@@ -47,7 +47,7 @@ namespace Markov
             this.maximumOrder = maximumOrder;
             this.desiredNumNextStates = desiredNumNextStates;
 
-            for (int order = maximumOrder; order > 0; order--)
+            for (var order = maximumOrder; order > 0; order--)
             {
                 this.chains.Add(new MarkovChain<T>(order));
             }
@@ -59,7 +59,7 @@ namespace Markov
         /// <param name="items">The items to add to the generator.</param>
         public void Add(IEnumerable<T> items)
         {
-            foreach (MarkovChain<T> chain in this.chains)
+            foreach (var chain in this.chains)
             {
                 chain.Add(items);
             }
@@ -73,13 +73,13 @@ namespace Markov
         /// <remarks>Assumes an empty starting state.</remarks>
         public IEnumerable<T> Chain(Random rand)
         {
-            Queue<T> workingQueue = new Queue<T>();
+            var workingQueue = new Queue<T>();
 
             while (true)
             {
-                foreach (MarkovChain<T> chain in this.chains)
+                foreach (var chain in this.chains)
                 {
-                    Dictionary<T, int> nextStates = chain.GetNextStates(workingQueue);
+                    var nextStates = chain.GetNextStates(workingQueue);
                     if (nextStates is null)
                     {
                         if (chain.Order <= 1)
@@ -94,17 +94,17 @@ namespace Markov
 
                     if (nextStates.Count >= this.desiredNumNextStates || chain.Order <= 1)
                     {
-                        int totalNonTerminalWeight = nextStates.Sum(w => w.Value);
+                        var totalNonTerminalWeight = nextStates.Sum(w => w.Value);
 
-                        int terminalWeight = chain.GetTerminalWeight(workingQueue);
-                        int randomValue = rand.Next(totalNonTerminalWeight + terminalWeight) + 1;
+                        var terminalWeight = chain.GetTerminalWeight(workingQueue);
+                        var randomValue = rand.Next(totalNonTerminalWeight + terminalWeight) + 1;
 
                         if (randomValue > totalNonTerminalWeight)
                         {
                             yield break;
                         }
 
-                        int currentWeight = 0;
+                        var currentWeight = 0;
                         foreach (var nextItem in nextStates)
                         {
                             currentWeight += nextItem.Value;

--- a/Markov/MarkovChainWithBackoff.cs
+++ b/Markov/MarkovChainWithBackoff.cs
@@ -80,6 +80,23 @@ namespace Markov
         }
 
         /// <inheritdoc/>
+        public override IEnumerable<ChainState<T>> GetStates()
+        {
+            foreach (var state in base.GetStates())
+            {
+                yield return state;
+            }
+
+            foreach (var chain in this.chains)
+            {
+                foreach (var state in chain.GetStates())
+                {
+                    yield return state;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
         public override int GetTerminalWeight(ChainState<T> state)
         {
             var orderTarget = this.GetDesiredOrderTarget(ref state, out var _);
@@ -88,6 +105,7 @@ namespace Markov
                 : this.chains[this.Order - orderTarget - 1].GetTerminalWeight(state);
         }
 
+        /// <inheritdoc/>
         protected internal override void AddTerminalInternal(ChainState<T> state, int weight)
         {
             var orderTarget = this.GetOrderTarget(state);

--- a/Markov/MarkovChainWithBackoff.cs
+++ b/Markov/MarkovChainWithBackoff.cs
@@ -13,7 +13,6 @@ namespace Markov
     public class MarkovChainWithBackoff<T>
         where T : IEquatable<T>
     {
-        private readonly int maximumOrder;
         private readonly List<MarkovChain<T>> chains = new List<MarkovChain<T>>();
         private readonly int desiredNumNextStates;
 
@@ -44,7 +43,6 @@ namespace Markov
                 throw new ArgumentOutOfRangeException(nameof(desiredNumNextStates));
             }
 
-            this.maximumOrder = maximumOrder;
             this.desiredNumNextStates = desiredNumNextStates;
 
             for (var order = maximumOrder; order > 0; order--)

--- a/Markov/MarkovChainWithBackoff.cs
+++ b/Markov/MarkovChainWithBackoff.cs
@@ -52,5 +52,17 @@ namespace Markov
                 this.chains.Add(new MarkovChain<T>(order));
             }
         }
+
+        /// <summary>
+        /// Adds the items to the generator with a weight of one.
+        /// </summary>
+        /// <param name="items">The items to add to the generator.</param>
+        public void Add(IEnumerable<T> items)
+        {
+            foreach (MarkovChain<T> chain in this.chains)
+            {
+                chain.Add(items);
+            }
+        }
     }
 }

--- a/Markov/MarkovChainWithBackoff.cs
+++ b/Markov/MarkovChainWithBackoff.cs
@@ -82,7 +82,7 @@ namespace Markov
                     Dictionary<T, int> nextStates = chain.GetNextStates(workingQueue);
                     if (nextStates is null)
                     {
-                        if (chain == this.chains.Last())
+                        if (chain.Order <= 1)
                         {
                             yield break;
                         }
@@ -92,7 +92,7 @@ namespace Markov
                         }
                     }
 
-                    if (nextStates.Count >= this.desiredNumNextStates || chain == this.chains.Last())
+                    if (nextStates.Count >= this.desiredNumNextStates || chain.Order <= 1)
                     {
                         int totalNonTerminalWeight = nextStates.Sum(w => w.Value);
 

--- a/license.md
+++ b/license.md
@@ -1,4 +1,4 @@
-Copyright © 2018 John Gietzen
+Copyright © 2018 John Gietzen and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -18,3 +18,6 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Contributors:
+    Zac Gross

--- a/stylecop.json
+++ b/stylecop.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
     "documentationRules": {
-      "copyrightText": "Copyright © John Gietzen. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.",
+      "copyrightText": "Copyright Â© John Gietzen and Contributors. All Rights Reserved. This source is subject to the MIT license. Please see license.md for more information.",
       "xmlHeader": false
     }
   }


### PR DESCRIPTION
Uses the existing MarkovChain to implement a chain with back-off. Back-off means that when constructing the chain you set a desired number of next possible states. If there isn't that many possible states, we decrease the order and try again until we either have enough possible states or we reach order 1.

Code was mostly migrated from https://github.com/brickman1444/CaptainRexEbooks/blob/master/MarkovChainWithBackoff.cs which was implemented against the description of back-off written here: https://blog.dataiku.com/2016/10/08/machine-learning-markov-chains-generate-clinton-trump-quotes

Updates the GitVersionTask dependency which was necessary in order to build the netcoreapp2.0 target on my machine.